### PR TITLE
Cast as string so we don't meaningless updates every time, showing no…

### DIFF
--- a/bugwarrior/services/trello.py
+++ b/bugwarrior/services/trello.py
@@ -49,7 +49,7 @@ class TrelloIssue(Issue):
         return self.build_default_description(
             title=self.record['name'],
             url=self.record['shortUrl'],
-            number=self.record['idShort'],
+            number=str(self.record['idShort']),
             cls='task',
         )
 
@@ -66,7 +66,7 @@ class TrelloIssue(Issue):
             'priority': self.origin['default_priority'],
             self.NAME: self.record['name'],
             self.CARDID: self.record['id'],
-            self.SHORTCARDID: self.record['idShort'],
+            self.SHORTCARDID: str(self.record['idShort']),
             self.DESCRIPTION: self.record['desc'],
             self.BOARD: self.extra['boardname'],
             self.LIST: self.extra['listname'],

--- a/tests/test_trello.py
+++ b/tests/test_trello.py
@@ -191,7 +191,7 @@ class TestTrelloService(ConfigTest):
             'trellolist': 'List 1',
             'trellocard': 'Card 1',
             'trellocardid': 'C4RD',
-            'trellocardidshort': 1,
+            'trellocardidshort': '1',
             'trellodescription': 'some description',
             'trelloshortlink': 'abcd',
             'trelloshorturl': 'https://trello.com/c/AAaaBBbb',


### PR DESCRIPTION
Hey, @lukas-reineke, every time I run `bugwarrior-pull` after applying this patch, it tries to update *every one of my tasks*, showing, for each one:
```
INFO:bugwarrior.db:Updating task b2e5bfd7-1786-46ae-b4f9-5187dfce0984, (bw)#235 - Research replacement printer .. https://trello.com/c/kvcttUZG; trellocardidshort: '235' -> 235                                                               
```

This PR fixes that problem by casting the Card Short ID to a string manually.